### PR TITLE
fix(MobileNav): allow expand on pages other than Home

### DIFF
--- a/src/components/MobileNav/index.tsx
+++ b/src/components/MobileNav/index.tsx
@@ -23,18 +23,11 @@ export const MobileNav = ({ user }: Props) => {
   return (
     <div className="mobile-nav">
       <nav className="indigo darken-4">
-        <a
-          href="#"
-          data-target="slide-out"
-          className="sidenav-trigger"
-          data-astro-reload
-        >
+        <a href="#" data-target="slide-out" className="sidenav-trigger">
           <i className="material-icons">menu</i>
         </a>
         <h1>
-          <a href="/" data-astro-reload>
-            FeedMe
-          </a>
+          <a href="/">FeedMe</a>
         </h1>
       </nav>
 
@@ -55,14 +48,10 @@ export const MobileNav = ({ user }: Props) => {
         {user && (
           <>
             <li>
-              <a href="/" data-astro-reload>
-                Home
-              </a>
+              <a href="/">Home</a>
             </li>
             <li>
-              <a href="/manage" data-astro-reload>
-                Manage Feeds
-              </a>
+              <a href="/manage">Manage Feeds</a>
             </li>
             <li>
               <div className="divider"></div>
@@ -80,9 +69,7 @@ export const MobileNav = ({ user }: Props) => {
 
         {!user && (
           <li>
-            <a href={loginUrl} data-astro-reload>
-              Login to Github
-            </a>
+            <a href={loginUrl}>Login to Github</a>
           </li>
         )}
       </ul>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,6 +1,5 @@
 ---
 import "@fontsource/pacifico";
-import { ViewTransitions } from "astro:transitions";
 import GlobalStyles from "components/GlobalStyles.astro";
 import { MobileNav } from "components/MobileNav";
 import Nav from "components/Nav.astro";
@@ -38,7 +37,6 @@ const user = getUser(Astro.cookies);
 
     <meta name="generator" content={Astro.generator} />
     <title>{title}</title>
-    <ViewTransitions />
   </head>
   <body class="dark-theme">
     <ThemeInitializer client:only="react" />


### PR DESCRIPTION
These changes temporarily disable view transitions to allow mobile nav to expand on pages other than the home page.