### PR TITLE
ui(AudioPlayer): remove padding from play button

### DIFF
--- a/src/components/FeedItemPage/AudioPlayer/styles.css
+++ b/src/components/FeedItemPage/AudioPlayer/styles.css
@@ -124,6 +124,7 @@
   cursor: pointer;
   width: 50px;
   height: 50px;
+  padding: 0;
 }
 
 .play-pause-btn:focus {


### PR DESCRIPTION
This fixes some spacing issues on Windows Firefox.